### PR TITLE
Introduce type-safe units from the [squants] library

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,8 @@ libraryDependencies ++= Seq(
   "io.github.dzufferey" %% "misc-scala-utils" % "0.1-SNAPSHOT",
   "com.twitter" %% "chill" % "0.9.1",
   "org.scalafx" %% "scalafx" % "8.0.102-R11",
-  "eu.mihosoft.vrl.jcsg" % "jcsg" % "0.5.2"
+  "eu.mihosoft.vrl.jcsg" % "jcsg" % "0.5.2",
+  "org.typelevel"  %% "squants"  % "1.2.0"
 )
 
 addCompilerPlugin("org.psywerx.hairyfotr" %% "linter" % "0.1.17")

--- a/src/main/scala/scadla/EverythingIsIn.scala
+++ b/src/main/scala/scadla/EverythingIsIn.scala
@@ -1,0 +1,8 @@
+package scadla
+
+import scala.language.implicitConversions
+
+object EverythingIsIn {
+  implicit def millimeters[A](n: A)(implicit num: Numeric[A]) = squants.space.Millimeters(n)
+  implicit def radians[A](n: A)(implicit num: Numeric[A]) = squants.space.Radians(n)
+}

--- a/src/main/scala/scadla/InlineOps.scala
+++ b/src/main/scala/scadla/InlineOps.scala
@@ -1,21 +1,33 @@
 package scadla
 
+import squants.space.Length
+import scala.language.postfixOps
+import squants.space.Millimeters
+import squants.space.Angle
+import squants.space.Degrees
+
 object InlineOps {
+  
+  implicit class AngleConversions[A](n: A)(implicit num: Numeric[A]) {
+    def ° = Degrees(n)
+  }
 
   implicit class Ops(lhs: Solid) {
+    import squants.space.LengthConversions._
 
-    def translate(x: Double, y: Double, z: Double) = Translate(x, y, z, lhs)
-    def move(x: Double, y: Double, z: Double) = Translate(x, y, z, lhs)
+    def translate(x: Length, y: Length, z: Length) = Translate(x, y, z, lhs)
+    def move(x: Length, y: Length, z: Length) = Translate(x, y, z, lhs)
     def move(v: Vector) = Translate(v, lhs)
-    def moveX(x: Double) = Translate(x, 0, 0, lhs)
-    def moveY(y: Double) = Translate(0, y, 0, lhs)
-    def moveZ(z: Double) = Translate(0, 0, z, lhs)
+    def move(p: Point) = Translate(p.toVector, lhs)
+    def moveX(x: Length) = Translate(x, 0 mm, 0 mm, lhs)
+    def moveY(y: Length) = Translate(0 mm, y, 0 mm, lhs)
+    def moveZ(z: Length) = Translate(0 mm, 0 mm, z, lhs)
 
-    def rotate(x: Double, y: Double, z: Double) = Rotate(x, y, z, lhs)
+    def rotate(x: Angle, y: Angle, z: Angle) = Rotate(x, y, z, lhs)
     def rotate(q: Quaternion) = Rotate(q, lhs)
-    def rotateX(x: Double) = Rotate(x, 0, 0, lhs)
-    def rotateY(y: Double) = Rotate(0, y, 0, lhs)
-    def rotateZ(z: Double) = Rotate(0, 0, z, lhs)
+    def rotateX(x: Angle) = Rotate(x, 0°, 0°, lhs)
+    def rotateY(y: Angle) = Rotate(0°, y, 0°, lhs)
+    def rotateZ(z: Angle) = Rotate(0°, 0°, z, lhs)
 
     def scale(x: Double, y: Double, z: Double) = Scale(x, y, z, lhs)
     def scaleX(x: Double) = Scale(x, 1, 1, lhs)
@@ -43,5 +55,4 @@ object InlineOps {
     def toPolyhedron = backends.Renderer.default(lhs) //TODO a way of being lazy
 
   }
-
 }

--- a/src/main/scala/scadla/Primitives.scala
+++ b/src/main/scala/scadla/Primitives.scala
@@ -1,9 +1,21 @@
 package scadla
 
-case class Point(x: Double, y: Double, z: Double) {
-  def to(p: Point) = Vector(p.x-x, p.y-y, p.z-z)
-  def toVector = Vector(x, y, z)
-  def toQuaternion = Quaternion(0, x, y, z)
+import squants.space.Length
+import squants.space.Area
+import squants.space.Millimeters
+import squants.space.LengthUnit
+import squants.space.AngleUnit
+import squants.space.Radians
+import squants.space.Angle
+
+case class Point(x: Length, y: Length, z: Length) {
+  private def unit = x.unit
+  def to(p: Point) = Vector(
+      (p.x - x).in(unit).value, 
+      (p.y - y).in(unit).value, 
+      (p.z - z).in(unit).value, unit)
+  def toVector = Vector(x.in(unit).value, y.in(unit).value, z.in(unit).value, unit)
+  def toQuaternion = Quaternion(0, x.in(unit).value, y.in(unit).value, z.in(unit).value, unit)
 }
 
 case class Face(p1: Point, p2: Point, p3: Point) {
@@ -11,7 +23,7 @@ case class Face(p1: Point, p2: Point, p3: Point) {
     val v1 = p1 to p2
     val v2 = p1 to p3
     val n1 = v1 cross v2
-    n1 / n1.norm
+    n1.toUnitVector
   }
   def flipOrientation = Face(p1, p3, p2)
 }
@@ -52,12 +64,12 @@ case class Matrix(m00: Double, m01: Double, m02: Double, m03:Double,
   }
 
   def *(p: Point): Point = {
-    val extended = Seq(p.x, p.y, p.z, 1)
+    val extended = Seq(p.x.toMillimeters, p.y.toMillimeters, p.z.toMillimeters, 1)
     val x = prod(row(0), extended)
     val y = prod(row(1), extended)
     val z = prod(row(2), extended)
     val w = prod(row(3), extended)
-    Point(x/w, y/w, z/w)
+    Point(Millimeters(x/w), Millimeters(y/w), Millimeters(z/w))
   }
 
   def *(q: Quaternion): Matrix = this * q.toMatrix
@@ -68,19 +80,19 @@ object Matrix {
                     0, 1, 0, 0,
                     0, 0, 1, 0,
                     0, 0, 0, 1)
-  def rotation(x: Double, y: Double, z: Double) = {
-    val qx = Quaternion.mkRotation(x, Vector(1,0,0))
-    val qy = Quaternion.mkRotation(y, Vector(0,1,0))
-    val qz = Quaternion.mkRotation(z, Vector(0,0,1))
+  def rotation(x: Angle, y: Angle, z: Angle) = {
+    val qx = Quaternion.mkRotation(x, Vector.x)
+    val qy = Quaternion.mkRotation(y, Vector.y)
+    val qz = Quaternion.mkRotation(z, Vector.z)
     val q = qx * (qy * qz)
     q.toMatrix
   }
 
   def mirror(_x: Double, _y: Double, _z: Double) = {
-    val v = Vector(_x,_y,_z).unit
-    val x = v.x
-    val y = v.y
-    val z = v.z
+    val v = Vector(_x,_y,_z,Millimeters).toUnitVector
+    val x = v.x.toMillimeters
+    val y = v.y.toMillimeters
+    val z = v.z.toMillimeters
     Matrix(1-2*x*x,  -2*y*x,  -2*z*x, 0,
             -2*x*y, 1-2*y*y,  -2*z*y, 0,
             -2*x*z,  -2*y*z, 1-2*z*z, 0,
@@ -89,67 +101,86 @@ object Matrix {
 
 }
 
-case class Vector(x: Double, y: Double, z: Double) {
-  def +(v: Vector): Vector = Vector(x+v.x, y+v.y, z+v.z)
-  def -(v: Vector): Vector = Vector(x-v.x, y-v.y, z-v.z)
-  def *(c: Double): Vector = Vector(c*x, c*y, c*z)
-  def /(c: Double): Vector = Vector(x/c, y/c, z/c)
-  def dot(v: Vector): Double = x*v.x + y*v.y + z*v.z
-  def cross(v: Vector): Vector = Vector(y*v.z - z*v.y, z*v.x - x*v.z, x*v.y - y*v.x)
-  def norm: Double = math.sqrt(x*x + y*y + z*z)
-  def unit = this / norm
-  def toQuaternion = Quaternion(0, x, y, z)
+case class Vector(private val _x: Double, private val _y: Double, private val _z: Double, unit: LengthUnit) {
+  def x = unit(_x)
+  def y = unit(_y)
+  def z = unit(_z)
+  def +(v: Vector): Vector = Vector(_x+v._x, _y+v._y, _z+v._z, unit)
+  def -(v: Vector): Vector = Vector(_x-v._x, _y-v._y, _z-v._z, unit)
+  def *(c: Double): Vector = Vector(_x*c, _y*c, _z*c, unit)
+  def /(c: Double): Vector = Vector(_x/c, _y/c, _z/c, unit)
+  def dot(v: Vector): Area = x*v.x + y*v.y + z*v.z
+  def cross(v: Vector) = Vector(_y*v._z - _z*v._y, _z*v._x - _x*v._z, _x*v._y - _y*v._x, unit)
+  private def _norm: Double = Math.sqrt(_x*_x + _y*_y + _z*_z)
+  def norm: Length = unit(_norm)
+  def toUnitVector: Vector = this / _norm
+  def toQuaternion = Quaternion(0, _x, _y, _z, unit)
+  def toQuaternion(real: Double) = Quaternion(real, _x, _y, _z, unit)
   def toPoint = Point(x, y, z)
   def rotateBy(q: Quaternion) = q.rotate(this)
 }
 
 object Vector {
-  def x = new Vector(1, 0, 0)
-  def y = new Vector(0, 1, 0)
-  def z = new Vector(0, 0, 1)
+  /** A 1mm vector pointing in the positive X direction */
+  def x = new Vector(1, 0, 0, Millimeters)
+  /** A 1mm vector pointing in the positive Y direction */
+  def y = new Vector(0, 1, 0, Millimeters)
+  /** A 1mm vector pointing in the positive Z direction */
+  def z = new Vector(0, 0, 1, Millimeters)
 }
 
-case class Quaternion(a: Double, i: Double, j: Double, k: Double) {
+case class Quaternion(a: Double, i: Double, j: Double, k: Double, unit: LengthUnit) {
   /** Hammilton product */
   def *(q: Quaternion) = Quaternion(a*q.a - i*q.i - j*q.j - k*q.k,
                                     a*q.i + i*q.a + j*q.k - k*q.j,
                                     a*q.j - i*q.k + j*q.a + k*q.i,
-                                    a*q.k + i*q.j - j*q.i + k*q.a)
-  def inverse = Quaternion(a, -i, -j, -k)
-  def norm: Double = math.sqrt(a*a + i*i + j*j + k*k)
-  def unit = {
-    val n = norm
-    Quaternion(a/n, i/n, j/n, k/n)
+                                    a*q.k + i*q.j - j*q.i + k*q.a, unit)
+  def inverse = Quaternion(a, -i, -j, -k, unit)
+  private def _norm: Double = math.sqrt(a*a + i*i + j*j + k*k) 
+  def norm: Length = unit(_norm) 
+  def toUnitQuaternion = {
+    val n = _norm
+    Quaternion(a/n, i/n, j/n, k/n, unit)
   }
-  def toVector = Vector(i, j, k)
-  def toPoint = Point(i, j, k)
+  def toVector = Vector(i, j, k, unit)
+  def toPoint = Point(unit(i), unit(j), unit(k))
   def toMatrix = Matrix(1 - 2*(j*j + k*k),     2*(i*j - k*a),     2*(i*k + j*a), 0,
                             2*(i*j + k*a), 1 - 2*(i*i + k*k),     2*(j*k - i*a), 0,
                             2*(i*k - j*a),     2*(j*k + i*a), 1 - 2*(i*i + j*j), 0,
                                         0,                 0,                 0, 1)
   /** Get the axis of rotation for an unit quaternion */
-  def getDirection = {
-    if (i == 0.0 && j == 0.0 && k == 0.0) Vector(1, 0, 0)
-    else toVector.unit
+  def getDirection: Vector = {
+    if (i == 0.0 && j == 0.0 && k == 0.0) Vector.x
+    else toVector.toUnitVector
   }
   /** Get the angle of rotation for an unit quaternion */
   def getAngle = 2 * math.acos(a)
   
   // https://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles
-  def toRollPitchYaw = Vector(
+  def toRollPitchYaw = RollPitchYaw(
     math.atan2(2 * (i*a + j*k), 1 - 2 * (i*i + j*j)),
     math.asin(2 * (a*k - i*k)),
-    math.atan2(2 * (a*k + i*j), 1 - 2 * (j*j + k*k))
+    math.atan2(2 * (a*k + i*j), 1 - 2 * (j*j + k*k)),
+    Radians
   )
 
   def rotate(v: Vector): Vector = (this * v.toQuaternion * inverse).toVector
   def rotate(p: Point): Point = (this * p.toQuaternion * inverse).toPoint
 }
 
+case class RollPitchYaw(_roll: Double, _pitch: Double, _yaw: Double, unit: AngleUnit) {
+  def roll = unit(_roll)
+  def x = roll
+  def pitch = unit(_pitch)
+  def y = pitch
+  def yaw = unit(_yaw)
+  def z = yaw
+}
+
 object Quaternion {
-  def mkRotation(alpha: Double, direction: Vector) = {
-    val a = math.cos(alpha / 2)
-    val d = direction.unit * math.sin(alpha / 2)
-    Quaternion(a, d.x, d.y, d.z)
+  def mkRotation(alpha: Angle, direction: Vector) = {
+    val a = (alpha / 2).cos
+    val d = direction.toUnitVector * (alpha / 2).sin
+    d.toQuaternion(a)
   }
 }

--- a/src/main/scala/scadla/Solid.scala
+++ b/src/main/scala/scadla/Solid.scala
@@ -1,11 +1,14 @@
 package scadla
 
+import squants.space.Length
+import squants.space.Angle
+
 sealed abstract class Solid 
 
 //basic shapes
-case class Cube(width: Double, depth: Double, height: Double) extends Solid
-case class Sphere(radius: Double) extends Solid
-case class Cylinder(radiusBot: Double, radiusTop: Double, height: Double) extends Solid
+case class Cube(width: Length, depth: Length, height: Length) extends Solid
+case class Sphere(radius: Length) extends Solid
+case class Cylinder(radiusBot: Length, radiusTop: Length, height: Length) extends Solid
 case class FromFile(path: String, format: String = "stl") extends Solid {
   def load: Polyhedron = format match {
     case "stl" => backends.stl.Parser(path)
@@ -28,8 +31,8 @@ case class Hull(objs: Solid*) extends Solid
 
 //transforms
 case class Scale(x: Double, y: Double, z: Double, obj: Solid) extends Solid
-case class Rotate(x: Double, y: Double, z: Double, obj: Solid) extends Solid
-case class Translate(x: Double, y: Double, z: Double, obj: Solid) extends Solid
+case class Rotate(x: Angle, y: Angle, z: Angle, obj: Solid) extends Solid
+case class Translate(x: Length, y: Length, z: Length, obj: Solid) extends Solid
 case class Mirror(x: Double, y: Double, z: Double, obj: Solid) extends Solid
 case class Multiply(m: Matrix, obj: Solid) extends Solid
 
@@ -40,7 +43,7 @@ case class Multiply(m: Matrix, obj: Solid) extends Solid
 /////////////////////////////
 
 object Cylinder {
-  def apply(radius: Double, height: Double): Cylinder = Cylinder(radius, radius, height)
+  def apply(radius: Length, height: Length): Cylinder = Cylinder(radius, radius, height)
 }
 
 object Translate {

--- a/src/main/scala/scadla/assembly/Assembly.scala
+++ b/src/main/scala/scadla/assembly/Assembly.scala
@@ -3,6 +3,10 @@ package scadla.assembly
 import scadla._
 import scadla.backends.Renderer
 import scala.language.implicitConversions
+import squants.space.Length
+import squants.time.Time
+import squants.time.Seconds
+import squants.space.Millimeters
 
 sealed abstract class Assembly(name: String, children: List[(Frame,Joint,Assembly,Frame)]) {
 
@@ -43,7 +47,7 @@ sealed abstract class Assembly(name: String, children: List[(Frame,Joint,Assembl
   def +(joint: Joint, child: Assembly): Assembly =
     this + (Frame(), joint, child, Frame())
   
-  def expandAt(expansion: Double, time: Double): Seq[(Frame,Polyhedron)] = {
+  def expandAt(expansion: Length, time: Time): Seq[(Frame,Polyhedron)] = {
     children.flatMap{ case (f1, j, c, f3) =>
       val f2 = j.expandAt(expansion, time)
       val f = f1.compose(f2).compose(f3)
@@ -52,9 +56,9 @@ sealed abstract class Assembly(name: String, children: List[(Frame,Joint,Assembl
     }
   }
 
-  def at(t: Double): Seq[(Frame,Polyhedron)] = expandAt(0, t)
+  def at(t: Time): Seq[(Frame,Polyhedron)] = expandAt(Millimeters(0), t)
 
-  def expand(t: Double): Seq[(Frame,Polyhedron)] = expandAt(t, 0)
+  def expand(t: Length): Seq[(Frame,Polyhedron)] = expandAt(t, Seconds(0))
   
   //TODO immutable
   def preRender(r: Renderer) {
@@ -111,7 +115,7 @@ case class SingletonAssembly(part: Part, children: List[(Frame,Joint,Assembly,Fr
     SingletonAssembly(part, (where, joint, child, whereChild) :: children)
   }
 
-  override def expandAt(e: Double, t: Double): Seq[(Frame,Polyhedron)] = super.expandAt(e, t) :+ (Frame() -> part.mesh)
+  override def expandAt(e: Length, t: Time): Seq[(Frame,Polyhedron)] = super.expandAt(e, t) :+ (Frame() -> part.mesh)
 
   override def preRender(r: Renderer) {
     super.preRender(r)

--- a/src/main/scala/scadla/assembly/Frame.scala
+++ b/src/main/scala/scadla/assembly/Frame.scala
@@ -1,6 +1,7 @@
 package scadla.assembly
 
 import scadla._
+import squants.space.Millimeters
 
 
 
@@ -39,7 +40,7 @@ case class Frame(translation: Vector, orientation: Quaternion) {
 }
 
 object Frame {
-  def apply(t: Vector): Frame = Frame(t, Quaternion(1,0,0,0))
-  def apply(q: Quaternion): Frame = Frame(Vector(0,0,0), q)
-  def apply(): Frame = Frame(Vector(0,0,0), Quaternion(1,0,0,0))
+  def apply(t: Vector): Frame = Frame(t, Quaternion(1,0,0,0, t.unit))
+  def apply(q: Quaternion): Frame = Frame(Vector(0,0,0, q.unit), q)
+  def apply(): Frame = Frame(Vector(0,0,0,Millimeters), Quaternion(1,0,0,0,Millimeters))
 }

--- a/src/main/scala/scadla/assembly/Joints.scala
+++ b/src/main/scala/scadla/assembly/Joints.scala
@@ -1,54 +1,63 @@
 package scadla.assembly
 
 import scadla._
+import squants.space.LengthUnit
+import squants.motion.AngularVelocity
+import squants.time.Time
+import squants.motion.Velocity
+import squants.space.Length
+import squants.space.Millimeters
+import squants.time.Seconds
+import squants.motion.MetersPerSecond
+import squants.motion.RadiansPerSecond
 
 case class Joint(direction: Vector,
-                 linearSpeed: Double,
-                 angularSpeed: Double) {
+                 linearSpeed: Velocity,
+                 angularSpeed: AngularVelocity) {
 
   //TODO need to know the bounding box of the two objects connected by this joint to scale appropriately
 
   //TODO override that for putting bounds on the rotation, e.g., hinges
-  def effectiveTime(time: Double) = time
+  def effectiveTime(time: Time) = time
 
-  def expandAt(expansion: Double, time: Double): Frame = {
+  def expandAt(expansion: Length, time: Time): Frame = {
     val effectiveT = effectiveTime(time)
     val r = Quaternion.mkRotation(angularSpeed * effectiveT, direction)
-    val l = direction * (linearSpeed * effectiveT + expansion)
+    val l = direction * (linearSpeed * effectiveT + expansion).in(direction.unit).value
     Frame(l, r)
   }
   
-  def expandAt(expansion: Double, time: Double, s: Solid): Solid = {
+  def expandAt(expansion: Length, time: Time, s: Solid): Solid = {
     val effectiveT = effectiveTime(time)
     val r = Quaternion.mkRotation(angularSpeed * effectiveT, direction)
-    val l = direction * (linearSpeed * effectiveT + expansion)
+    val l = direction * (linearSpeed * effectiveT + expansion).in(direction.unit).value
     Translate(l, Rotate(r, s))
   }
 
-  def at(t: Double): Frame = expandAt(0, t)
+  def at(t: Time): Frame = expandAt(Millimeters(0), t)
 
-  def at(t: Double, s: Solid): Solid = expandAt(0, t, s)
+  def at(t: Time, s: Solid): Solid = expandAt(Millimeters(0), t, s)
   
-  def expand(t: Double): Frame = expandAt(t, 0)
+  def expand(t: Length): Frame = expandAt(t, Seconds(0))
 
-  def expand(t: Double, s: Solid): Solid = expandAt(t, 0, s)
+  def expand(t: Length, s: Solid): Solid = expandAt(t, Seconds(0), s)
 
 }
 
 object Joint {
   
-  def fixed(direction: Vector): Joint = new Joint(direction, 0, 0)
-  def fixed(x:Double, y: Double, z: Double): Joint = fixed(Vector(x,y,z))
+  def fixed(direction: Vector): Joint = new Joint(direction, MetersPerSecond(0), RadiansPerSecond(0))
+  def fixed(x:Double, y: Double, z: Double, unit: LengthUnit): Joint = fixed(Vector(x,y,z, unit))
   
-  def revolute(direction: Vector): Joint = new Joint(direction, 0, 1)
-  def revolute(direction: Vector, angularSpeed: Double): Joint = new Joint(direction, 0, angularSpeed)
-  def revolute(x:Double, y: Double, z: Double, angularSpeed: Double = 1.0): Joint = revolute(Vector(x,y,z), angularSpeed)
+  def revolute(direction: Vector): Joint = new Joint(direction, MetersPerSecond(0), RadiansPerSecond(1))
+  def revolute(direction: Vector, angularSpeed: AngularVelocity): Joint = new Joint(direction, MetersPerSecond(0), angularSpeed)
+  def revolute(x:Double, y: Double, z: Double, unit: LengthUnit, angularSpeed: AngularVelocity = RadiansPerSecond(1)): Joint = revolute(Vector(x,y,z,unit), angularSpeed)
 
-  def prismatic(direction: Vector): Joint = new Joint(direction, 1, 0)
-  def prismatic(direction: Vector, linearSpeed: Double): Joint = new Joint(direction, linearSpeed, 0)
-  def prismatic(x:Double, y: Double, z: Double, linearSpeed: Double = 1.0): Joint = prismatic(Vector(x,y,z), linearSpeed)
+  def prismatic(direction: Vector): Joint = new Joint(direction, MetersPerSecond(1), RadiansPerSecond(0))
+  def prismatic(direction: Vector, linearSpeed: Velocity): Joint = new Joint(direction, linearSpeed, RadiansPerSecond(0))
+  def prismatic(x:Double, y: Double, z: Double, unit: LengthUnit, linearSpeed: Velocity = MetersPerSecond(0.001)): Joint = prismatic(Vector(x,y,z,unit), linearSpeed)
 
-  def screw(direction: Vector, linearSpeed: Double, angularSpeed: Double): Joint = new Joint(direction, linearSpeed, angularSpeed)
-  def screw(x:Double, y: Double, z: Double, linearSpeed: Double = 1.0, angularSpeed: Double = 1.0): Joint = screw(Vector(x,y,z), linearSpeed, angularSpeed)
+  def screw(direction: Vector, linearSpeed: Velocity, angularSpeed: AngularVelocity): Joint = new Joint(direction, linearSpeed, angularSpeed)
+  def screw(x:Double, y: Double, z: Double, unit: LengthUnit, linearSpeed: Velocity = MetersPerSecond(0.001), angularSpeed: AngularVelocity = RadiansPerSecond(1)): Joint = screw(Vector(x,y,z,unit), linearSpeed, angularSpeed)
 
 }

--- a/src/main/scala/scadla/backends/OpenSCAD.scala
+++ b/src/main/scala/scadla/backends/OpenSCAD.scala
@@ -60,7 +60,7 @@ class OpenSCAD(header: List[String]) extends Renderer {
         case Empty =>
           writer.newLine
         case Cube(width, depth, height) =>
-          writer.write("cube([ " + width + ", " + depth + ", " + height + "]);")
+          writer.write("cube([ " + width.toMillimeters + ", " + depth.toMillimeters + ", " + height.toMillimeters + "]);")
           writer.newLine
         case Sphere(radius) =>
           writer.write("sphere( " + radius + ");")
@@ -71,7 +71,7 @@ class OpenSCAD(header: List[String]) extends Renderer {
         case p @ Polyhedron(_) =>
           val (indexedP,indexedF) = p.indexed
           writer.write("polyhedron( points=[ ")
-          writer.write(indexedP.map{ case Point(x,y,z) => "["+x+","+y+","+z+"]" }.mkString(", "))
+          writer.write(indexedP.map(p => "["+p.x.toMillimeters+","+p.y.toMillimeters+","+p.z.toMillimeters+"]").mkString(", "))
           writer.write(" ], faces=[ ")
           writer.write(indexedF.map{ case (a,b,c) => "["+a+","+b+","+c+"]" }.mkString(", "))
           writer.write(" ]);")
@@ -124,7 +124,7 @@ class OpenSCAD(header: List[String]) extends Renderer {
           writer.newLine
           prnt(obj, indent+2)
         case Rotate(x, y, z, obj) =>
-          writer.write("rotate(["+math.toDegrees(x)+","+math.toDegrees(y)+","+math.toDegrees(z)+"])")
+          writer.write("rotate(["+x.toDegrees+","+y.toDegrees+","+z.toDegrees+"])")
           writer.newLine
           prnt(obj, indent+2)
         case Translate(x, y, z, obj) =>

--- a/src/main/scala/scadla/backends/amf/Parser.scala
+++ b/src/main/scala/scadla/backends/amf/Parser.scala
@@ -5,24 +5,29 @@ import scala.util.parsing.combinator._
 import dzufferey.utils._
 import dzufferey.utils.LogLevel._
 import scala.xml._
+import squants.space.LengthUnit
+import squants.space.Millimeters
+import squants.space.Microns
+import squants.space.Meters
+import squants.space.Inches
 
 object Parser {
   
   def apply(fileName: String): Polyhedron = {
     val amf = XML.loadFile(fileName)
-    val unitFactor: Double = amf \@ "unit" match {
-      case "millimeter" | "" | null  => 1
-      case "meter" => 0.001
-      case "micrometer" => 1000
-      case "inch" => 25.4
+    val unit: LengthUnit = amf \@ "unit" match {
+      case "millimeter" | "" | null  => Millimeters
+      case "meter" => Meters
+      case "micrometer" => Microns
+      case "inch" => Inches
       case other => Logger.logAndThrow("amf.Parser", Error, "unkown unit: " + other)
     }
     def parseVertex(v: Node): Point = {
       val coord = v \ "coordinates"
-      val x = (coord \ "x").text.toDouble * unitFactor
-      val y = (coord \ "y").text.toDouble * unitFactor
-      val z = (coord \ "z").text.toDouble * unitFactor
-      Point(x,y,z)
+      val x = (coord \ "x").text.toDouble
+      val y = (coord \ "y").text.toDouble
+      val z = (coord \ "z").text.toDouble
+      Point(unit(x),unit(y),unit(z))
     }
     def parseFace(triangle: Node): (Int, Int, Int) = {
       val a = (triangle \ "v1").text.toInt

--- a/src/main/scala/scadla/backends/amf/Printer.scala
+++ b/src/main/scala/scadla/backends/amf/Printer.scala
@@ -10,15 +10,15 @@ object Printer {
   def store(obj: Polyhedron, fileName: String) = {
     val (points, faces) = obj.indexed
     val pointNodes =
-      new Group(points.map{ case Point(x,y,z) =>
-        <vertex><coordinates><x>{x}</x><y>{y}</y><z>{z}</z></coordinates></vertex>
+      new Group(points.map{ p =>
+        <vertex><coordinates><x>{p.x.toMillimeters}</x><y>{p.y.toMillimeters}</y><z>{p.z.toMillimeters}</z></coordinates></vertex>
       })
     val faceNodes =
       new Group(faces.map{ case (a,b,c) =>
         <triangle><v1>{a}</v1><v2>{b}</v2><v3>{c}</v3></triangle>
       }.toSeq)
     val node =
-      <amf unit="milimeter">
+      <amf unit="millimeter">
         <metadata type="producer">Scadla</metadata>
         <object id="0">
           <mesh>

--- a/src/main/scala/scadla/backends/obj/Parser.scala
+++ b/src/main/scala/scadla/backends/obj/Parser.scala
@@ -5,6 +5,7 @@ import scala.util.parsing.combinator._
 import dzufferey.utils._
 import dzufferey.utils.LogLevel._
 import java.io._
+import squants.space.Millimeters
 
 // https://en.wikipedia.org/wiki/Wavefront_.obj_file
 // We assume that the faces are oriented and only triangles
@@ -25,8 +26,8 @@ object Parser extends JavaTokenParsers {
 
   def parseVertex: Parser[Point] =
     "v" ~> repN(3, floatingPointNumber) ~ opt(floatingPointNumber) ^^ {
-      case List(a, b,c) ~ None => Point(a.toDouble, b.toDouble, c.toDouble)
-      case List(a, b,c) ~ Some(w) => Point(a.toDouble / w.toDouble, b.toDouble / w.toDouble, c.toDouble / w.toDouble)
+      case List(a, b,c) ~ None => Point(Millimeters(a.toDouble), Millimeters(b.toDouble), Millimeters(c.toDouble))
+      case List(a, b,c) ~ Some(w) => Point(Millimeters(a.toDouble / w.toDouble), Millimeters(b.toDouble / w.toDouble), Millimeters(c.toDouble / w.toDouble))
     }
 
 

--- a/src/main/scala/scadla/backends/obj/Printer.scala
+++ b/src/main/scala/scadla/backends/obj/Printer.scala
@@ -13,8 +13,8 @@ object Printer {
       val (points, faces) = obj.indexed
       writer.write("g ScadlaObject")
       writer.newLine
-      points.foreach{ case Point(x,y,z) =>
-        writer.write("v " + x + " " + y + " " + z)
+      points.foreach{ p =>
+        writer.write("v " + p.x.toMillimeters + " " + p.y.toMillimeters + " " + p.z.toMillimeters)
         writer.newLine
       }
       writer.newLine

--- a/src/main/scala/scadla/backends/ply/Printer.scala
+++ b/src/main/scala/scadla/backends/ply/Printer.scala
@@ -26,8 +26,8 @@ object Printer {
     val writer = new BufferedWriter(new FileWriter(fileName))
     try {
       printHeader(writer, points.length, faces.size)
-      points.foreach{ case Point(x,y,z) =>
-        writer.write(x + " " + y + " " + z)
+      points.foreach{ p =>
+        writer.write(p.x.toMillimeters + " " + p.y.toMillimeters + " " + p.z.toMillimeters)
         writer.newLine
       }
       faces.foreach{ case (a,b,c) =>

--- a/src/main/scala/scadla/backends/stl/Printer.scala
+++ b/src/main/scala/scadla/backends/stl/Printer.scala
@@ -37,9 +37,9 @@ object Printer {
       out.order(ByteOrder.LITTLE_ENDIAN)
     }
     def outputPoint(p: Point) {
-      out.putFloat(p.x.toFloat)
-      out.putFloat(p.y.toFloat)
-      out.putFloat(p.z.toFloat)
+      out.putFloat(p.x.toMillimeters.toFloat)
+      out.putFloat(p.y.toMillimeters.toFloat)
+      out.putFloat(p.z.toMillimeters.toFloat)
     }
     val header = Array.fill[Byte](80)(' '.toByte)
     "Generated with Scadla".getBytes.copyToArray(header)
@@ -47,9 +47,9 @@ object Printer {
     out.putInt(obj.faces.size)
     obj.faces.foreach{ case f @ Face(p1, p2, p3) =>
       val n = f.normal
-      out.putFloat(n.x.toFloat)
-      out.putFloat(n.y.toFloat)
-      out.putFloat(n.z.toFloat)
+      out.putFloat(n.x.toMillimeters.toFloat)
+      out.putFloat(n.y.toMillimeters.toFloat)
+      out.putFloat(n.z.toMillimeters.toFloat)
       outputPoint(p1)
       outputPoint(p2)
       outputPoint(p3)

--- a/src/main/scala/scadla/examples/BeltMold.scala
+++ b/src/main/scala/scadla/examples/BeltMold.scala
@@ -29,6 +29,8 @@ class BeltMold(length: Double,
                jacket: Double,
                tolerance: Double) {
 
+  import scadla.EverythingIsIn.{millimeters, radians}
+  
   val innerRadius = length / 2 / Pi
   val outerRadius = innerRadius + threadDiameter + 2*jacket
   val height = threadDiameter * threadTurns + 2*jacket

--- a/src/main/scala/scadla/examples/ComponentStorageBox.scala
+++ b/src/main/scala/scadla/examples/ComponentStorageBox.scala
@@ -4,6 +4,7 @@ import math._
 import scadla._
 import utils._
 import InlineOps._
+import scadla.EverythingIsIn.{millimeters, radians}  
 
 class ComponentStorageBox(
     width: Double,

--- a/src/main/scala/scadla/examples/GearBearing.scala
+++ b/src/main/scala/scadla/examples/GearBearing.scala
@@ -5,6 +5,8 @@ import scadla._
 import utils._
 import utils.gear._
 import InlineOps._
+import scadla.utils.gear.Twist.radiansPerMm
+import scadla.EverythingIsIn.{millimeters, radians}  
 
 //inspired by Emmet's Gear Bearing (http://www.thingiverse.com/thing:53451)
 
@@ -15,7 +17,7 @@ object GearBearing {
             nbrPlanets: Int,
             nbrTeethPlanet: Int,
             nbrTeethSun: Int,
-            helixAngleOuter: Double,
+            helixAngleOuter: Twist,
             pressureAngle: Double,
             centerHexagonMinRadius: Double,
             backlash: Double) = {
@@ -25,7 +27,7 @@ object GearBearing {
 
   def main(args: Array[String]) {
     //val gears = apply(35, 10, 5, 10, 15, 0.02, toRadians(40), 5, 0.1)
-    val gears = apply(35, 10, 5, 6, 10, 0.02, toRadians(60), 5, 0.1)
+    val gears = apply(35, 10, 5, 6, 10, radiansPerMm(0.02), toRadians(60), 5, 0.1)
     backends.Renderer.default.view(gears.all)
   }
 
@@ -36,7 +38,7 @@ class GearBearing(val outerRadius: Double,
                   val nbrPlanets: Int,
                   val nbrTeethPlanet: Int,
                   val nbrTeethSun: Int,
-                  val helixAngleOuter: Double,
+                  val helixAngleOuter: Twist,
                   val pressureAngle: Double,
                   val centerHexagonMinRadius: Double,
                   val backlash: Double) {
@@ -50,7 +52,7 @@ class GearBearing(val outerRadius: Double,
     default * coeff
   }
 
-  protected def gear(pitch: Double, nbrTeeth: Int, helix: Double) = {
+  protected def gear(pitch: Double, nbrTeeth: Int, helix: Twist) = {
     val add = addenum( pitch, nbrTeeth)
     HerringboneGear(pitch, nbrTeeth, pressureAngle, add, add, height, helix, backlash)
   }
@@ -60,8 +62,8 @@ class GearBearing(val outerRadius: Double,
   val planetRadius = outerRadius / (2 + sunToPlanetRatio)
   val sunRadius = planetRadius * sunToPlanetRatio
   val nbrTeethOuter = 2 * nbrTeethPlanet + nbrTeethSun
-  val helixAnglePlanet = helixAngleOuter * outerRadius / planetRadius
-  val helixAngleSun = -(helixAngleOuter * outerRadius / sunRadius)
+  val helixAnglePlanet = helixAngleOuter * (outerRadius / planetRadius)
+  val helixAngleSun = -(helixAngleOuter * (outerRadius / sunRadius))
 
   def externalRadius = outerRadius + addenum(outerRadius, nbrTeethOuter) + Gear.baseThickness
 

--- a/src/main/scala/scadla/examples/MecanumWheel.scala
+++ b/src/main/scala/scadla/examples/MecanumWheel.scala
@@ -4,6 +4,8 @@ import math._
 import scadla._
 import utils._
 import InlineOps._
+import scadla.EverythingIsIn.{millimeters, radians}  
+import squants.space.Millimeters
 
 /** A class for the small rollers in the mecanum wheel */
 class Roller(height: Double, maxOuterRadius: Double, minOuterRadius: Double, innerRadius: Double) {
@@ -204,19 +206,19 @@ class MecanumWheel(radius: Double, width: Double, angle: Double, nbrRollers: Int
     val upperP = new Part("hub, upper half", upper, Some(upper.rotate(Pi, 0, 0).moveZ(-width/2)))
     val asmbl0 = Assembly("Mecanum wheel")
     def place(as: Assembly, c: Assembly, w: Vector) = {
-      val jt = Joint.revolute(0,0,1)
-      val f0 = Frame(Vector(innerR,0,width/2), Quaternion.mkRotation(angle, Vector(1,0,0)))
+      val jt = Joint.revolute(0,0,1,Millimeters)
+      val f0 = Frame(Vector(innerR,0,width/2,Millimeters), Quaternion.mkRotation(angle, Vector(1,0,0,Millimeters)))
       (0 until nbrRollers).foldLeft(as)( (acc, i) => {
-        val f1 = Frame(Vector(0,0,0), Quaternion.mkRotation(i * 2 * Pi / nbrRollers, Vector(0,0,1)))
+        val f1 = Frame(Vector(0,0,0,Millimeters), Quaternion.mkRotation(i * 2 * Pi / nbrRollers, Vector(0,0,1,Millimeters)))
         val frame = f0.compose(f1)
         acc + (frame, jt, c, w)
       })
     }
     val asmbl1 = asmbl0 +
-                (Joint.fixed(0,0,-1), lowerP) +
-                (Joint.fixed(0,0, 1), upperP)
-    val asmbl2 = place(asmbl1, rollerP, Vector(0,0,-rollerHeight/2))
-    place(asmbl2, axle, Vector(0,0,-axleHeight))
+                (Joint.fixed(0,0,-1,Millimeters), lowerP) +
+                (Joint.fixed(0,0, 1,Millimeters), upperP)
+    val asmbl2 = place(asmbl1, rollerP, Vector(0,0,-rollerHeight/2,Millimeters))
+    place(asmbl2, axle, Vector(0,0,-axleHeight,Millimeters))
   }
 
 }

--- a/src/main/scala/scadla/examples/WhiteboardMarkerHolder.scala
+++ b/src/main/scala/scadla/examples/WhiteboardMarkerHolder.scala
@@ -4,6 +4,7 @@ import math._
 import scadla._
 import utils._
 import InlineOps._
+import scadla.EverythingIsIn.{millimeters, radians}  
 
 object WhiteboardMarkerHolder {
 

--- a/src/main/scala/scadla/examples/cnc/ActuatorFastener.scala
+++ b/src/main/scala/scadla/examples/cnc/ActuatorFastener.scala
@@ -6,6 +6,7 @@ import utils._
 import InlineOps._
 import Common._
 import scadla.examples.fastener._
+import scadla.EverythingIsIn.{millimeters, radians}  
 
 // dX, dZ are given from the center of the extrusion
 class ActuatorFasterner(dX: Double, dZ: Double) {

--- a/src/main/scala/scadla/examples/cnc/BitsHolder.scala
+++ b/src/main/scala/scadla/examples/cnc/BitsHolder.scala
@@ -5,6 +5,7 @@ import scadla._
 import utils._
 import InlineOps._
 import scadla.examples.fastener._
+import scadla.EverythingIsIn.{millimeters, radians}  
 
 object BitsHolder {
 

--- a/src/main/scala/scadla/examples/cnc/Chuck.scala
+++ b/src/main/scala/scadla/examples/cnc/Chuck.scala
@@ -6,6 +6,7 @@ import utils._
 import InlineOps._
 import scadla.examples.fastener._
 import Common._
+import scadla.EverythingIsIn.{millimeters, radians}  
 
 object Chuck {
 
@@ -26,7 +27,7 @@ object Chuck {
   val nutHeight = nut.height(shaft)
     val body = Union(
       Cylinder(outerRadius, chuckHeight - 5).moveZ(5),
-      doubleHex(Hexagon.minRadius(outerRadius), 5)
+      doubleHex(Hexagon.minRadius(outerRadius).toMillimeters, 5)
     )
     val toRemove = List(
       threading.screwThreadIsoInner(mNumber, colletLength),
@@ -41,7 +42,7 @@ object Chuck {
   //TODO some more parameters
   def wrench(outerRadius: Double) = {
     val wall = 5
-    val hex = doubleHex(Hexagon.minRadius(outerRadius) + looseTolerance, 5)
+    val hex = doubleHex(Hexagon.minRadius(outerRadius).toMillimeters + looseTolerance, 5)
     val head = Cylinder(outerRadius + wall, 5)
     val handle = RoundedCubeH(outerRadius*6, outerRadius*2, 5, 3)
     head + handle.moveY(-outerRadius) - hex

--- a/src/main/scala/scadla/examples/cnc/Collet.scala
+++ b/src/main/scala/scadla/examples/cnc/Collet.scala
@@ -6,6 +6,7 @@ import utils._
 import InlineOps._
 import scadla.examples.fastener._
 import Common._
+import scadla.EverythingIsIn.{millimeters, radians}  
 
 object Collet {
 

--- a/src/main/scala/scadla/examples/cnc/Common.scala
+++ b/src/main/scala/scadla/examples/cnc/Common.scala
@@ -4,6 +4,7 @@ import scadla._
 import utils._
 import InlineOps._
 import scadla.examples.fastener._
+import scadla.EverythingIsIn.{millimeters, radians}  
 
 object Common {
   

--- a/src/main/scala/scadla/examples/cnc/Frame.scala
+++ b/src/main/scala/scadla/examples/cnc/Frame.scala
@@ -6,6 +6,8 @@ import scadla.utils._
 import scala.math._
 import scadla.examples.extrusion._
 import Common._
+import scadla.EverythingIsIn.{millimeters, radians}  
+import squants.space.Millimeters
 
 // TODO
 // - the parts for the cable to improve the rigidity
@@ -68,7 +70,7 @@ object Frame {
     val y = Cube(20,20,20+8.5).move(-20, 0,-20) + Cube(20, 20, 20).move(0,0,-20)
     val offsetX = 2 + 8.5 * sin(Pi/6) // 8.5 is T bottom part
     val y2 = y.rotateY(-Pi/6).moveX(offsetX)
-    val p = Vector(3, 1.5, 0).rotateBy(Quaternion.mkRotation(Pi/6, Vector(0,0,1)))
+    val p = Vector(3, 1.5, 0,Millimeters).rotateBy(Quaternion.mkRotation(Pi/6, Vector(0,0,1,Millimeters)))
     val s = screws.move(-p.y, offsetX - p.x, 0)
     Difference(
       x,
@@ -152,8 +154,8 @@ object Frame {
       val x = 30
       CenteredCube(x,x,x).rotate(Pi/4,Pi/4,0).moveY(-5) * c - corner
     }
-    val q = Quaternion.mkRotation(-2*Pi/3, Vector(0,0,1))
-    val p = Vector(-3, 1.5, 0).rotateBy(q)
+    val q = Quaternion.mkRotation(-2*Pi/3, Vector(0,0,1,Millimeters))
+    val p = Vector(-3, 1.5, 0,Millimeters).rotateBy(q)
     base + diagonal + angle - screws.move(-p.x, 8.5 * sin(Pi/6) - p.y, -2)
   }
   
@@ -207,22 +209,22 @@ object Frame {
 
   // part that goes between the feet and the frame to keep the 2π/3 angle
   protected def anglePlate = {
-    val q1 = Quaternion.mkRotation( Pi/6, Vector(0,0,1))
-    val q2 = Quaternion.mkRotation(-Pi/6, Vector(0,0,1))
+    val q1 = Quaternion.mkRotation( Pi/6, Vector(0,0,1,Millimeters))
+    val q2 = Quaternion.mkRotation(-Pi/6, Vector(0,0,1,Millimeters))
     val c1 = Cylinder(10, thickness)
     val c2 = Cylinder(boltSize + tolerance, thickness)
     val offsetY = 5.5
     val positions1 = Seq(
-      Vector( screwOffsetX1, offsetY, 0).rotateBy(q1),
-      Vector( screwOffsetX2, offsetY, 0).rotateBy(q1),
-      Vector(-screwOffsetX1, offsetY, 0).rotateBy(q2),
-      Vector(-screwOffsetX2, offsetY, 0).rotateBy(q2)
+      Vector( screwOffsetX1, offsetY, 0,Millimeters).rotateBy(q1),
+      Vector( screwOffsetX2, offsetY, 0,Millimeters).rotateBy(q1),
+      Vector(-screwOffsetX1, offsetY, 0,Millimeters).rotateBy(q2),
+      Vector(-screwOffsetX2, offsetY, 0,Millimeters).rotateBy(q2)
     )
     val positions2 = Seq(
-      Vector( screwOffsetX1, screwOffsetY1, 0).rotateBy(q1),
-      Vector( screwOffsetX2, screwOffsetY1, 0).rotateBy(q1),
-      Vector(-screwOffsetX1, screwOffsetY1, 0).rotateBy(q2),
-      Vector(-screwOffsetX2, screwOffsetY1, 0).rotateBy(q2)
+      Vector( screwOffsetX1, screwOffsetY1, 0,Millimeters).rotateBy(q1),
+      Vector( screwOffsetX2, screwOffsetY1, 0,Millimeters).rotateBy(q1),
+      Vector(-screwOffsetX1, screwOffsetY1, 0,Millimeters).rotateBy(q2),
+      Vector(-screwOffsetX2, screwOffsetY1, 0,Millimeters).rotateBy(q2)
     )
     val base = Hull(c1.scale(1.5, 0.5, 1).moveY(10) ++ positions1.map(p => c1.move(p)))
     base -- positions2.map(p => c2.move(p))

--- a/src/main/scala/scadla/examples/cnc/Gimbal.scala
+++ b/src/main/scala/scadla/examples/cnc/Gimbal.scala
@@ -6,6 +6,7 @@ import utils._
 import InlineOps._
 import scadla.examples.fastener._
 import Common._
+import scadla.EverythingIsIn.{millimeters, radians}  
 
 //The part that holds the linear actuator connected to the frame
 

--- a/src/main/scala/scadla/examples/cnc/Joints.scala
+++ b/src/main/scala/scadla/examples/cnc/Joints.scala
@@ -6,6 +6,7 @@ import utils._
 import InlineOps._
 import scadla.examples.fastener._
 import Common._
+import scadla.EverythingIsIn.{millimeters, radians}  
 
 /** A 2 degree of freedom joint.
  *  @param bottomNut is the size of bottom thread/nut

--- a/src/main/scala/scadla/examples/cnc/LinearActuator.scala
+++ b/src/main/scala/scadla/examples/cnc/LinearActuator.scala
@@ -9,6 +9,7 @@ import scadla.examples.fastener._
 import scadla.examples.GearBearing
 import Common._
 import scadla.examples.reach3D.SpoolHolder
+import scadla.EverythingIsIn.{millimeters, radians}  
 
 
 //TODO need to add some springy thing on one nut to reduce the backlash (preload)
@@ -42,13 +43,13 @@ object LinearActuator {
 
   val motorGearRadius = motorYOffset * nbrTeethMotor / (nbrTeethMotor + nbrTeethRod)
   val rodGearRadius =   motorYOffset * nbrTeethRod   / (nbrTeethMotor + nbrTeethRod)
-  val mHelix = -0.1
+  val mHelix = Twist(-0.1)
   val rHelix = -mHelix * motorGearRadius / rodGearRadius
   
   val grooveDepthBase = bbRadius / cos(Pi/4) - bearingGapBase / 2
   val grooveDepthSupport = bbRadius / cos(Pi/4) - bearingGapSupport / 2
   val grooveRadiusBase = SpoolHolder.adjustGrooveRadius(nut.maxOuterRadius(rodThread) + grooveDepthBase + 1) // +1 for the adjust radius
-  val grooveRadiusSupport = SpoolHolder.adjustGrooveRadius(rodGearRadius - Gear.addenum(rodGearRadius, nbrTeethRod) - grooveDepthSupport)
+  val grooveRadiusSupport = SpoolHolder.adjustGrooveRadius(rodGearRadius - Gear.addenum(rodGearRadius, nbrTeethRod).toMillimeters - grooveDepthSupport)
 
   val grooveBase = SpoolHolder.flatGroove(grooveRadiusBase, grooveDepthBase)
   val grooveSupport = SpoolHolder.flatGroove(grooveRadiusSupport, grooveDepthSupport)

--- a/src/main/scala/scadla/examples/cnc/Motors.scala
+++ b/src/main/scala/scadla/examples/cnc/Motors.scala
@@ -4,6 +4,7 @@ import scadla._
 import scadla.InlineOps._
 import scadla.utils._
 import scala.math._
+import scadla.EverythingIsIn.{millimeters, radians}  
 
 //TODO move that to the lib
 //place holder for NEMA stepper motors

--- a/src/main/scala/scadla/examples/cnc/Platform.scala
+++ b/src/main/scala/scadla/examples/cnc/Platform.scala
@@ -5,6 +5,7 @@ import scadla._
 import utils._
 import InlineOps._
 import Common._
+import scadla.EverythingIsIn.{millimeters, radians}  
 
 //a platform to put hold the spindle
 object Platform {

--- a/src/main/scala/scadla/examples/cnc/Pulley.scala
+++ b/src/main/scala/scadla/examples/cnc/Pulley.scala
@@ -6,6 +6,7 @@ import utils._
 import InlineOps._
 import scadla.examples.fastener._
 import Common._
+import scadla.EverythingIsIn.{millimeters, radians}  
 
 object Pulley {
   

--- a/src/main/scala/scadla/examples/cnc/Spindle.scala
+++ b/src/main/scala/scadla/examples/cnc/Spindle.scala
@@ -7,6 +7,7 @@ import utils.gear._
 import InlineOps._
 import scadla.examples.fastener._
 import Common._
+import scadla.EverythingIsIn.{millimeters, radians}  
 
 //parameters:
 //- thickness of structure
@@ -72,8 +73,8 @@ object Spindle {
   // gears //
   ///////////
 
-  lazy val gear1 = Gear.helical( motorBoltDistance * 2 / 3.0, 32, gearHeight,-0.03, tolerance)
-  lazy val gear2 = Gear.helical( motorBoltDistance / 3.0    , 16, gearHeight, 0.06, tolerance)
+  lazy val gear1 = Gear.helical( motorBoltDistance * 2 / 3.0, 32, gearHeight, Twist(-0.03), tolerance)
+  lazy val gear2 = Gear.helical( motorBoltDistance / 3.0    , 16, gearHeight, Twist(0.06), tolerance)
   val motorKnobs = {
     val c = Cylinder(3-tolerance, 2).moveZ(gearHeight)
     val u = Union(c.moveX(9), c.moveX(-9), c.moveY(9), c.moveY(-9))

--- a/src/main/scala/scadla/examples/extrusion/C.scala
+++ b/src/main/scala/scadla/examples/extrusion/C.scala
@@ -3,6 +3,7 @@ package scadla.examples.extrusion
 import scadla._
 import scadla.InlineOps._
 import scadla.utils._
+import scadla.EverythingIsIn.{millimeters, radians}  
 
 object C {
 

--- a/src/main/scala/scadla/examples/extrusion/H.scala
+++ b/src/main/scala/scadla/examples/extrusion/H.scala
@@ -3,6 +3,7 @@ package scadla.examples.extrusion
 import scadla._
 import scadla.InlineOps._
 import scadla.utils._
+import scadla.EverythingIsIn.{millimeters, radians}  
 
 //actually: more like a double T
 object H {

--- a/src/main/scala/scadla/examples/extrusion/L.scala
+++ b/src/main/scala/scadla/examples/extrusion/L.scala
@@ -3,6 +3,7 @@ package scadla.examples.extrusion
 import scadla._
 import scadla.InlineOps._
 import scadla.utils._
+import scadla.EverythingIsIn.{millimeters, radians}  
 
 object L {
 

--- a/src/main/scala/scadla/examples/extrusion/T.scala
+++ b/src/main/scala/scadla/examples/extrusion/T.scala
@@ -3,6 +3,7 @@ package scadla.examples.extrusion
 import scadla._
 import scadla.InlineOps._
 import scadla.utils._
+import scadla.EverythingIsIn.{millimeters, radians}  
 
 object T {
 

--- a/src/main/scala/scadla/examples/extrusion/U.scala
+++ b/src/main/scala/scadla/examples/extrusion/U.scala
@@ -3,6 +3,7 @@ package scadla.examples.extrusion
 import scadla._
 import scadla.InlineOps._
 import scadla.utils._
+import scadla.EverythingIsIn.{millimeters, radians}  
 
 object U {
 

--- a/src/main/scala/scadla/examples/extrusion/Z.scala
+++ b/src/main/scala/scadla/examples/extrusion/Z.scala
@@ -3,6 +3,7 @@ package scadla.examples.extrusion
 import scadla._
 import scadla.InlineOps._
 import scadla.utils._
+import scadla.EverythingIsIn.{millimeters, radians}  
 
 object Z {
   

--- a/src/main/scala/scadla/examples/extrusion/_2020.scala
+++ b/src/main/scala/scadla/examples/extrusion/_2020.scala
@@ -4,6 +4,7 @@ import scadla._
 import scadla.InlineOps._
 import scadla.utils._
 import scala.math._
+import scadla.EverythingIsIn.{millimeters, radians}  
 
 //place holder for 20x20mm aluminium extrusions
 object _2020 {

--- a/src/main/scala/scadla/examples/fastener/MetricThread.scala
+++ b/src/main/scala/scadla/examples/fastener/MetricThread.scala
@@ -4,6 +4,7 @@ import scadla._
 import scadla.utils._
 import math._
 import InlineOps._
+import scadla.EverythingIsIn.{millimeters, radians}  
 
 /** Generate threaded rods, screws and nuts.
  * based on metric_iso_screw.scad by stth

--- a/src/main/scala/scadla/examples/fastener/Nut.scala
+++ b/src/main/scala/scadla/examples/fastener/Nut.scala
@@ -4,6 +4,7 @@ import scadla._
 import scadla.utils._
 import math._
 import InlineOps._
+import scadla.EverythingIsIn.{millimeters, radians}  
 
 object Nut {
 
@@ -52,7 +53,7 @@ class NutPlaceHolder(tolerance: Double = 0.1) {
   }
   
   def minOuterRadius(innerRadius: Double) = factor * innerRadius + tolerance
-  def maxOuterRadius(innerRadius: Double) = Hexagon.maxRadius(minOuterRadius(innerRadius))
+  def maxOuterRadius(innerRadius: Double) = Hexagon.maxRadius(minOuterRadius(innerRadius)).toMillimeters
   def height(innerRadius: Double) = factor * innerRadius + tolerance
 
   def M1   = apply( Thread.ISO.M1 )

--- a/src/main/scala/scadla/examples/fastener/Washer.scala
+++ b/src/main/scala/scadla/examples/fastener/Washer.scala
@@ -2,6 +2,7 @@ package scadla.examples.fastener
 
 import scadla._
 import scadla.utils._
+import scadla.EverythingIsIn.{millimeters, radians}  
 
 object Washer {
 

--- a/src/main/scala/scadla/examples/reach3D/ReachLegs.scala
+++ b/src/main/scala/scadla/examples/reach3D/ReachLegs.scala
@@ -4,6 +4,7 @@ import math._
 import scadla._
 import utils._
 import InlineOps._
+import scadla.EverythingIsIn.{millimeters, radians}  
 
 /** Some legs for the Reach3D printer */
 object ReachLegs {

--- a/src/main/scala/scadla/examples/reach3D/SpoolHolder.scala
+++ b/src/main/scala/scadla/examples/reach3D/SpoolHolder.scala
@@ -5,6 +5,7 @@ import scadla._
 import utils._
 import InlineOps._
 import scadla.examples.fastener.StructuralNutPlaceHolder
+import scadla.EverythingIsIn.{millimeters, radians}  
 
 object SpoolHolder {
 

--- a/src/main/scala/scadla/utils/Bigger.scala
+++ b/src/main/scala/scadla/utils/Bigger.scala
@@ -1,16 +1,17 @@
 package scadla.utils
   
 import scadla._
+import squants.space.Length
 
 object Bigger {
 
-  def apply(obj: Solid, s: Double) = Minkowski(obj, CenteredCube(s,s,s))
+  def apply(obj: Solid, s: Length) = Minkowski(obj, CenteredCube(s,s,s))
 
 }
 
 object BiggerS {
 
-  def apply(obj: Solid, s: Double) = Minkowski(obj, Sphere(s))
+  def apply(obj: Solid, s: Length) = Minkowski(obj, Sphere(s))
 
 
 }

--- a/src/main/scala/scadla/utils/CenteredCube.scala
+++ b/src/main/scala/scadla/utils/CenteredCube.scala
@@ -1,21 +1,24 @@
 package scadla.utils
   
 import scadla._
+import squants.space.Length
+import scala.language.postfixOps
+import squants.space.LengthConversions._
 
 object CenteredCube {
 
-  def apply(x: Double, y: Double, z:Double) = Translate(-x/2, -y/2, -z/2, Cube(x,y,z))
+  def apply(x: Length, y: Length, z:Length) = Translate(-x/2, -y/2, -z/2, Cube(x,y,z))
 
-  def xy(x: Double, y: Double, z:Double) = Translate(-x/2, -y/2, 0, Cube(x,y,z))
+  def xy(x: Length, y: Length, z:Length) = Translate(-x/2, -y/2, 0 mm, Cube(x,y,z))
 
-  def xz(x: Double, y: Double, z:Double) = Translate(-x/2, 0, -z/2, Cube(x,y,z))
+  def xz(x: Length, y: Length, z:Length) = Translate(-x/2, 0 mm, -z/2, Cube(x,y,z))
 
-  def yz(x: Double, y: Double, z:Double) = Translate(0, -y/2, -z/2, Cube(x,y,z))
+  def yz(x: Length, y: Length, z:Length) = Translate(0 mm, -y/2, -z/2, Cube(x,y,z))
 
-  def x(x: Double, y: Double, z:Double) = Translate(-x/2, 0, 0, Cube(x,y,z))
+  def x(x: Length, y: Length, z:Length) = Translate(-x/2, 0 mm, 0 mm, Cube(x,y,z))
 
-  def y(x: Double, y: Double, z:Double) = Translate(0, -y/2, 0, Cube(x,y,z))
+  def y(x: Length, y: Length, z:Length) = Translate(0 mm, -y/2, 0 mm, Cube(x,y,z))
 
-  def z(x: Double, y: Double, z:Double) = Translate(0, 0, -z/2, Cube(x,y,z))
+  def z(x: Length, y: Length, z:Length) = Translate(0 mm, 0 mm, -z/2, Cube(x,y,z))
 
 }

--- a/src/main/scala/scadla/utils/Hexagon.scala
+++ b/src/main/scala/scadla/utils/Hexagon.scala
@@ -3,19 +3,23 @@ package scadla.utils
 import scadla._
 import InlineOps._
 import scala.math._
+import squants.space.Length
+import squants.space.Radians
 
 object Hexagon {
 
-  def maxRadius(minRadius: Double) = minRadius / math.sin(math.Pi/3)
+  def maxRadius(minRadius: Length) = minRadius / math.sin(math.Pi/3)
 
-  def minRadius(maxRadius: Double) = maxRadius * math.sin(math.Pi/3)
+  def minRadius(maxRadius: Length) = maxRadius * math.sin(math.Pi/3)
 
   /* Extrude vertically an hexagon (centered at 0,0 with z from 0 to height)
    * @param minRadius the radius of the circle inscribed in the hexagon
    * @param height
    */
-  def apply(minRadius: Double, height: Double) = {
-    if (minRadius <= 0.0 || height <= 0.0) {
+  def apply(minRadius: Length, _height: Length) = {
+    val unit = minRadius.unit
+    val height = _height.in(unit)
+    if (minRadius.value <= 0.0 || height.value <= 0.0) {
       Empty
     } else {
       import scala.math._
@@ -49,12 +53,12 @@ object Hexagon {
    * @param radius2 the radius of the circle inscribed in the hexagon odd faces
    * @param height
    */
-  def semiRegular(radius1: Double, radius2: Double, height: Double) = {
-    val r = max(maxRadius(radius1), maxRadius(radius2))
+  def semiRegular(radius1: Length, radius2: Length, height: Length) = {
+    val r = maxRadius(radius1) max maxRadius(radius2)
     val base = Cylinder(r,height)
     val chop = Cube(r, 2*r, height).moveY(-r)
-    val neg1 = for(i <- 0 until 6 if i % 2 == 0) yield chop.moveX(radius1).rotateZ(i * Pi / 3)
-    val neg2 = for(i <- 0 until 6 if i % 2 == 1) yield chop.moveX(radius2).rotateZ(i * Pi / 3)
+    val neg1 = for(i <- 0 until 6 if i % 2 == 0) yield chop.moveX(radius1).rotateZ(Radians(i * Pi / 3))
+    val neg2 = for(i <- 0 until 6 if i % 2 == 1) yield chop.moveX(radius2).rotateZ(Radians(i * Pi / 3))
     base -- neg1 -- neg2
   }
 

--- a/src/main/scala/scadla/utils/PieSlice.scala
+++ b/src/main/scala/scadla/utils/PieSlice.scala
@@ -1,35 +1,41 @@
 package scadla.utils
   
 import scadla._
+import scadla.InlineOps._
+import squants.space.Length
+import squants.space.Angle
+import scala.language.postfixOps
+import squants.space.LengthConversions._
+import squants.space.Radians
 
 object PieSlice {
 
-  def apply(outerRadius: Double, innerRadius: Double, angle: Double, height: Double) = {
-    val o1 = outerRadius + 1
+  def apply(outerRadius: Length, innerRadius: Length, angle: Angle, height: Length) = {
+    val o1 = outerRadius + (1 mm)
     val t = Tube(outerRadius, innerRadius, height)
-    val blocking_half = Translate(-o1, -o1, -0.5, Cube(2* o1, o1, height + 1))
-    val blocking_quarter = Translate(0, 0, -0.5, Cube(o1, o1, height + 1))
-    if (angle <= 0) {
+    val blocking_half = Translate(-o1, -o1, -0.5 mm, Cube(2* o1, o1, height + (1 mm)))
+    val blocking_quarter = Translate(0 mm, 0 mm, -0.5 mm, Cube(o1, o1, height + (1 mm)))
+    if (angle.value <= 0) {
       Empty
     } else {
       val block =
-        if (angle <= math.Pi/2) {
+        if (angle <= Radians(math.Pi/2)) {
           Union(
             blocking_half,
-            Translate(-o1, -0.5, 0, blocking_quarter),
-            Rotate(0, 0, angle, blocking_quarter))
-        } else if (angle <= math.Pi) {
+            Translate(-o1, -0.5 mm, 0 mm, blocking_quarter),
+            Rotate(0°, 0°, angle, blocking_quarter))
+        } else if (angle <= Radians(math.Pi)) {
           Union(
             blocking_half,
-            Rotate(0, 0, angle, blocking_quarter))
-        } else if (angle <= 3*math.Pi/2) {
+            Rotate(0°, 0°, angle, blocking_quarter))
+        } else if (angle <= Radians(3*math.Pi/2)) {
           Union(
-            Translate(0, -o1, 0, blocking_quarter),
-            Rotate(0, 0, angle, blocking_quarter))
-        } else if (angle <= 2*math.Pi) {
+            Translate(0 mm, -o1, 0 mm, blocking_quarter),
+            Rotate(0°, 0°, angle, blocking_quarter))
+        } else if (angle <= Radians(2*math.Pi)) {
           Intersection(
-            Translate(0, -o1, 0, blocking_quarter),
-            Rotate(0, 0, angle, blocking_quarter))
+            Translate(0 mm, -o1, 0 mm, blocking_quarter),
+            Rotate(0°, 0°, angle, blocking_quarter))
         } else {
           Empty
         }

--- a/src/main/scala/scadla/utils/RoundedCube.scala
+++ b/src/main/scala/scadla/utils/RoundedCube.scala
@@ -1,12 +1,14 @@
 package scadla.utils
   
 import scadla._
-
+import squants.space.Length
+import scala.language.postfixOps
+import squants.space.LengthConversions._
 
 object RoundedCube {
 
-  def apply(x: Double, y: Double, z: Double, r: Double) = {
-    if (r > 0) {
+  def apply(x: Length, y: Length, z: Length, r: Length) = {
+    if (r.value > 0) {
       val d = 2*r
       assert(d < x && d < y && d < z, "RoundedCube, radius should be less than x/2, y/2, z/2.")
       val c = Translate(r, r, r, Cube(x - d, y - d, z - d))
@@ -21,12 +23,12 @@ object RoundedCube {
 
 object RoundedCubeH {
 
-  def apply(x: Double, y: Double, z: Double, r: Double) = {
-    if (r > 0) {
+  def apply(x: Length, y: Length, z: Length, r: Length) = {
+    if (r.value > 0) {
       val h = z/2
       val d = 2*r
       assert(d < x && d < y, "roundedCube, radius should be less than x/2, y/2.")
-      val c = Translate(r, r, 0, Cube(x - d, y - d, h))
+      val c = Translate(r, r, 0 mm, Cube(x - d, y - d, h))
       Minkowski(c, Cylinder(r, h))
     } else {
       Cube(x,y,z)

--- a/src/main/scala/scadla/utils/Smaller.scala
+++ b/src/main/scala/scadla/utils/Smaller.scala
@@ -1,14 +1,16 @@
 package scadla.utils
   
 import scadla._
+import squants.space.Millimeters
+import squants.space.Length
 
 //try to emulate a Minkowski difference
 //works only for objects that are not too concave
 
 object Smaller {
 
-  def apply(obj: Solid, s: Double) = {
-    val epsilon = 1e-6
+  def apply(obj: Solid, s: Length) = {
+    val epsilon = Millimeters(1e-6)
     val larger = Minkowski(obj, CenteredCube(epsilon, epsilon, epsilon))
     val shell = Difference(larger, obj)
     val biggerShell = Minkowski(shell, CenteredCube(s, s, s))
@@ -19,8 +21,8 @@ object Smaller {
 
 object SmallerS {
 
-  def apply(obj: Solid, s: Double) = {
-    val epsilon = 1e-6
+  def apply(obj: Solid, s: Length) = {
+    val epsilon = Millimeters(1e-6)
     val larger = Minkowski(obj, Sphere(epsilon))
     val shell = Difference(larger, obj)
     val biggerShell = Minkowski(shell, Sphere(s))

--- a/src/main/scala/scadla/utils/SpherePortion.scala
+++ b/src/main/scala/scadla/utils/SpherePortion.scala
@@ -3,47 +3,51 @@ package scadla.utils
 import scadla._
 import scadla.InlineOps._
 import math._
+import squants.space.Length
+import squants.space.Millimeters
+import squants.space.Angle
+import squants.space.Radians
 
 /** same idea as PieSlice with with a sphere */
 object SpherePortion {
 
   //TODO check https://en.wikipedia.org/wiki/Spherical_coordinate_system for the conventions
 
-  def apply(outerRadius: Double, innerRadius: Double,
-            inclinationStart: Double, inclinationEnd: Double,
-            azimut: Double) = {
-    val i = if (innerRadius > 0) Sphere(innerRadius) else Empty
-    val o1 = outerRadius + 1
+  def apply(outerRadius: Length, innerRadius: Length,
+            inclinationStart: Angle, inclinationEnd: Angle,
+            azimut: Angle) = {
+    val i = if (innerRadius.value > 0) Sphere(innerRadius) else Empty
+    val o1 = outerRadius + Millimeters(1)
     val carved = Difference(
       Sphere(outerRadius),
       pointyThing(o1, inclinationStart),
-      Mirror(0,0,1, pointyThing(o1, Pi - inclinationEnd)),
+      Mirror(0,0,1, pointyThing(o1, Radians(Pi) - inclinationEnd)),
       i
     )
     val sliced = Intersection(
       carved,
-      PieSlice(o1, 0, azimut, 2*o1).moveZ(-o1)
+      PieSlice(o1, Millimeters(0), azimut, 2*o1).moveZ(-o1)
     )
     sliced
   }
   
-  def elevation(outerRadius: Double, innerRadius: Double,
-                elevationStart: Double, elevationEnd: Double,
-                azimut: Double) = {
-    apply(outerRadius, innerRadius, Pi/2 - elevationStart, Pi/2 - elevationEnd, azimut)
+  def elevation(outerRadius: Length, innerRadius: Length,
+                elevationStart: Angle, elevationEnd: Angle,
+                azimut: Angle) = {
+    apply(outerRadius, innerRadius, Radians(Pi/2) - elevationStart, Radians(Pi/2) - elevationEnd, azimut)
   }
 
-  private def pointyThing(radius: Double, inclination: Double) = {
+  private def pointyThing(radius: Length, inclination: Angle) = {
     val c = Cylinder(radius, 2*radius)
-    val t = tan(inclination)
+    val t = inclination.tan
     val h = radius / t
-    if (inclination <= 0)           Empty
-    else if (inclination <= Pi/4)   Cylinder(0, radius * t, radius)
-    else if (inclination <  Pi/2)   Cylinder(0, radius, h) + c.moveZ(h)
-    else if (inclination == Pi/2)   c
-    else if (inclination <= 3*Pi/4) c.moveZ(h) - Cylinder(radius, 0, -h).moveZ(h)
-    else if (inclination <  Pi)     c.moveZ(-radius) - Cylinder(-h, 0, radius).moveZ(-radius)
-    else                            c.moveZ(-radius)
+    if (inclination <= Radians(0))           Empty
+    else if (inclination <= Radians(Pi/4))   Cylinder(Millimeters(0), radius * t, radius)
+    else if (inclination <  Radians(Pi/2))   Cylinder(Millimeters(0), radius, h) + c.moveZ(h)
+    else if (inclination == Radians(Pi/2))   c
+    else if (inclination <= Radians(3*Pi/4)) c.moveZ(h) - Cylinder(radius, Millimeters(0), -h).moveZ(h)
+    else if (inclination <  Radians(Pi))     c.moveZ(-radius) - Cylinder(-h, Millimeters(0), radius).moveZ(-radius)
+    else                                     c.moveZ(-radius)
   }
 
 }

--- a/src/main/scala/scadla/utils/Trapezoid.scala
+++ b/src/main/scala/scadla/utils/Trapezoid.scala
@@ -1,19 +1,22 @@
 package scadla.utils
   
 import scadla._
+import squants.space.Length
+import squants.space.Millimeters
 
 object Trapezoid {
 
-  def apply(xTop: Double, xBottom: Double, y: Double, z: Double, skew: Double = 0.0): Polyhedron = {
+  def apply(xTop: Length, xBottom: Length, y: Length, z: Length, skew: Double = 0.0): Polyhedron = {
     val skewOffest = z * math.tan(skew)
     val d = (xBottom-xTop)/2
+    val O = Millimeters(0)
     val pts = Seq(
-      Point(0, 0, 0),
-      Point(xBottom, 0, 0),
-      Point(xBottom, y, 0),
-      Point(0, y, 0),
-      Point(d + skewOffest, 0, z),
-      Point(xBottom - d + skewOffest, 0, z),
+      Point(O, O, O),
+      Point(xBottom, O, O),
+      Point(xBottom, y, O),
+      Point(O, y, O),
+      Point(d + skewOffest, O, z),
+      Point(xBottom - d + skewOffest, O, z),
       Point(xBottom - d + skewOffest, y, z),
       Point(d + skewOffest, y, z)
     )

--- a/src/main/scala/scadla/utils/Tube.scala
+++ b/src/main/scala/scadla/utils/Tube.scala
@@ -1,13 +1,16 @@
 package scadla.utils
   
 import scadla._
+import squants.space.Length
+import scala.language.postfixOps
+import squants.space.LengthConversions._
 
 object Tube {
 
-  def apply(outerRadius: Double, innerRadius: Double, height: Double) = {
+  def apply(outerRadius: Length, innerRadius: Length, height: Length) = {
     Difference(
       Cylinder(outerRadius, height),
-      Translate( 0, 0, -1, Cylinder(innerRadius, height + 2))
+      Translate(0 mm, 0 mm, -1 mm, Cylinder(innerRadius, height + (2 mm)))
     )
   }
 

--- a/src/main/scala/scadla/utils/box/Box.scala
+++ b/src/main/scala/scadla/utils/box/Box.scala
@@ -1,6 +1,7 @@
 package scadla.utils.box
 
 import scadla._
+import squants.space.Length
 
 case class Box(x: Interval, y: Interval, z: Interval) {
 
@@ -52,7 +53,7 @@ case class Box(x: Interval, y: Interval, z: Interval) {
     ))
   }
 
-  def move(x: Double, y: Double, z: Double) =
+  def move(x: Length, y: Length, z: Length) =
     if (isEmpty) Box.empty else {
       Box(this.x.move(x), this.y.move(y), this.z.move(z))
     }
@@ -92,8 +93,8 @@ object Box {
   val empty = Box(Interval.empty, Interval.empty, Interval.empty)
   val unit = Box(Interval.unit, Interval.unit, Interval.unit)
 
-  def apply(xMin: Double, yMin: Double, zMin: Double,
-            xMax: Double, yMax: Double, zMax: Double): Box =
+  def apply(xMin: Length, yMin: Length, zMin: Length,
+            xMax: Length, yMax: Length, zMax: Length): Box =
     Box(Interval(xMin, xMax),
         Interval(yMin, yMax),
         Interval(zMin, zMax))

--- a/src/main/scala/scadla/utils/box/InBox.scala
+++ b/src/main/scala/scadla/utils/box/InBox.scala
@@ -4,21 +4,23 @@ import scadla._
 import scala.math._
 import dzufferey.utils.Logger
 import dzufferey.utils.LogLevel._
+import squants.space.Millimeters
 
 object InBox {
 
+  private val O = Millimeters(0)
   def apply(s: Solid): Box = s match {
     case Cube(w, d, h) =>
-      Box(0, 0, 0, w, d, h)
+      Box(O, O, O, w, d, h)
     case Empty =>
       Box.empty
     case Sphere(r) =>
       val s = r * sqrt(2)/2
       Box(-s, -s, -s, s, s, s)
     case Cylinder(radiusBot, radiusTop, height) =>
-      val r = math.min(radiusBot,radiusTop)
+      val r = radiusBot min radiusTop
       val s = r * sqrt(2)/2
-      Box(-s, -s, 0, s, s, height)
+      Box(-s, -s, O, s, s, height)
     case Polyhedron(faces) =>
       Logger("InBox", Warning, "TODO InBox(Polyhedron)")
       Box.empty
@@ -46,7 +48,7 @@ object InBox {
       val neg = BoundingBox(Union(lst:_*))
       remove(pos, neg)
     case Minkowski(lst @ _*) =>
-      val init = Box(0,0,0,0,0,0)
+      val init = Box(O,O,O,O,O,O)
       if (lst.isEmpty) Box.empty
       else lst.foldLeft(init)( (b,s) => b.add(apply(s)) )
     case Hull(lst @ _*) =>

--- a/src/main/scala/scadla/utils/box/Interval.scala
+++ b/src/main/scala/scadla/utils/box/Interval.scala
@@ -1,16 +1,19 @@
 package scadla.utils.box
 
 import scadla._
+import squants.space.Length
+import squants.space.Millimeters
 
-case class Interval(min: Double, max: Double) {
+case class Interval(min: Length, max: Length) {
 
+  //TODO consider replacing Interval with QuantityRange, PR missing operators into squants
   //TODO better handling of degenerate case where min==max
 
   def isEmpty = min > max
 
-  def contains(x: Double) = x >= min && x <= max
+  def contains(x: Length) = x >= min && x <= max
 
-  def size = math.max(0.0, max - min)
+  def size = (max - min).max(min.unit(0))
 
   def contains(i: Interval) =
     i.isEmpty || (i.min >= min && i.max <= max)
@@ -21,7 +24,7 @@ case class Interval(min: Double, max: Double) {
   
   def center = (max - min) / 2
 
-  def move(x: Double) =
+  def move(x: Length) =
     if (isEmpty) this
     else Interval(x + min, x + max)
 
@@ -29,7 +32,7 @@ case class Interval(min: Double, max: Double) {
     if (isEmpty) this
     else Interval(x * min, x * max)
 
-  def intersection(b: Interval) = Interval(math.max(min,b.min), math.min(max,b.max))
+  def intersection(b: Interval) = Interval(min.max(b.min), max.min(b.max))
 
   def add(b: Interval) =
     if (isEmpty || b.isEmpty) Interval.empty
@@ -38,7 +41,7 @@ case class Interval(min: Double, max: Double) {
   def hull(b: Interval) =
     if (isEmpty) b
     else if (b.isEmpty) this 
-    else Interval(math.min(min, b.min), math.max(max, b.max))
+    else Interval(min.min(b.min), max.max(b.max))
 
   // hull(this \ b)
   def remove(b: Interval) =
@@ -60,6 +63,6 @@ case class Interval(min: Double, max: Double) {
 }
 
 object Interval {
-  val empty = Interval(1, -1)
-  val unit = Interval(0, 1)
+  val empty = Interval(Millimeters(1), Millimeters(-1))
+  val unit = Interval(Millimeters(0), Millimeters(1))
 }

--- a/src/main/scala/scadla/utils/gear/Gear.scala
+++ b/src/main/scala/scadla/utils/gear/Gear.scala
@@ -3,6 +3,8 @@ package scadla.utils.gear
 import scadla._
 import scadla.InlineOps._
 import scala.math._
+import squants.space.Millimeters
+import squants.space.Length
 
 //some references read when coding this
 //  https://en.wikipedia.org/wiki/Involute_gear
@@ -21,24 +23,24 @@ object Gear {
 
   /** This determines the number of vertical steps for helical and herringbone gear.
    *  This should more or less corresponds to the thickness of the layer when printing */
-  var zResolution = 0.2
+  var zResolution = Millimeters(0.2)
 
   /** only for rack and internal gears: thickness of the outer */
-  var baseThickness = 2
+  var baseThickness = Millimeters(2)
 
   /** default value for the addenum given the pitch and the number of teeth */
-  def addenum(pitch: Double, nbrTeeth: Int) = pitch.abs * 2 / nbrTeeth
+  def addenum(pitch: Length, nbrTeeth: Int) = pitch.abs * 2 / nbrTeeth
   
   /** suggested value for the pitch given the number of teeth and the addenum */
-  def pitch(nbrTeeth: Int, addenum: Double) = addenum / 2 * nbrTeeth
+  def pitch(nbrTeeth: Int, addenum: Length) = addenum / 2 * nbrTeeth
   
   /** aprroximative value for the number of teeth given the pitch and the addenum */
-  def approxNbrTeeth(pitch: Double, addenum: Double) = pitch / addenum * 2
+  def approxNbrTeeth(pitch: Length, addenum: Length) = pitch / addenum * 2
 
   /** Simplified interface for spur gear (try to guess some parameters).
    *  To mesh gears of different sizes, the pitch/nbrTeeth ratio must be the same for all the gears.
    */
-  def spur(pitch: Double, nbrTeeth: Int, height: Double, backlash: Double) = {
+  def spur(pitch: Length, nbrTeeth: Int, height: Length, backlash: Length) = {
     val add = addenum( pitch, nbrTeeth)
     InvoluteGear(pitch, nbrTeeth, toRadians(25), add, add, height, backlash)
   }
@@ -47,7 +49,7 @@ object Gear {
    *  Typical helix is 0.05
    *  To mesh gears of different sizes, the pitch/nbrTeeth and pitch/helix ratio must be the same for all the gears.
    */
-  def helical(pitch: Double, nbrTeeth: Int, height: Double, helix: Double, backlash: Double) = {
+  def helical(pitch: Length, nbrTeeth: Int, height: Length, helix: Twist, backlash: Length) = {
     val add = addenum( pitch, nbrTeeth)
     HelicalGear(pitch, nbrTeeth, toRadians(25), add, add, height, helix, backlash)
   }
@@ -55,7 +57,7 @@ object Gear {
   /** simplified interface for herringbone gear (try to guess some parameters)
    *  To mesh gears of different sizes, the pitch/nbrTeeth and pitch/helix ratio must be the same for all the gears.
    */
-  def herringbone(pitch: Double, nbrTeeth: Int, height: Double, helix: Double, backlash: Double) = {
+  def herringbone(pitch: Length, nbrTeeth: Int, height: Length, helix: Twist, backlash: Length) = {
     val add = addenum( pitch, nbrTeeth)
     HerringboneGear(pitch, nbrTeeth, toRadians(25), add, add, height, helix, backlash)
   }
@@ -63,7 +65,7 @@ object Gear {
   /** Simplified interface for rack (try to guess some parameters).
    * TODO what needs to match for gears to mesh
    */
-  def rack(toothWidth: Double, nbrTeeth: Int, height: Double, backlash: Double) = {
+  def rack(toothWidth: Length, nbrTeeth: Int, height: Length, backlash: Length) = {
     val add = toothWidth / 2 
     Rack(toothWidth, nbrTeeth, toRadians(25), add, add, height, backlash)
   }

--- a/src/main/scala/scadla/utils/gear/HelicalGear.scala
+++ b/src/main/scala/scadla/utils/gear/HelicalGear.scala
@@ -3,6 +3,8 @@ package scadla.utils.gear
 import scadla._
 import scadla.InlineOps._
 import scala.math._
+import squants.space.Angle
+import squants.space.Length
 
 object HelicalGear {
 
@@ -18,25 +20,25 @@ object HelicalGear {
    * @param addenum how much to add to the pitch to get the outer radius of the gear
    * @param dedenum how much to remove to the pitch to get the root radius of the gear
    * @param height the height of the gear
-   * @param helixAngle how much twisting (in rad / mm)
+   * @param twist how much twisting
    * @param backlash add some space (manufacturing tolerance)
    * @param skew generate a gear with an asymmetric profile by skewing the tooths
    */
-  def apply( pitch: Double,
+  def apply( pitch: Length,
              nbrTeeth: Int,
              pressureAngle: Double,
-             addenum: Double,
-             dedenum: Double,
-             height: Double,
-             helixAngle: Double,
-             backlash: Double,
+             addenum: Length,
+             dedenum: Length,
+             height: Length,
+             twist: Twist,
+             backlash: Length,
              skew: Double = 0.0) = {
     val stepped = InvoluteGear.stepped(pitch, nbrTeeth, pressureAngle, addenum, dedenum, height, backlash, skew)
     def turnPoint(p: Point): Point = {
       val z = p.z
-      val a = helixAngle * z
-      val x = p.x * cos(a) - p.y * sin(a)
-      val y = p.x * sin(a) + p.y * cos(a)
+      val a = twist.angle * (z / twist.increment)
+      val x = p.x * a.cos - p.y * a.sin
+      val y = p.x * a.sin + p.y * a.cos
       Point(x, y, z)
     }
     Polyhedron(stepped.faces.map( f => Face(turnPoint(f.p1), turnPoint(f.p2), turnPoint(f.p3)) ))

--- a/src/main/scala/scadla/utils/gear/HerringboneGear.scala
+++ b/src/main/scala/scadla/utils/gear/HerringboneGear.scala
@@ -3,6 +3,7 @@ package scadla.utils.gear
 import scadla._
 import scadla.InlineOps._
 import scala.math._
+import squants.space.Length
 
 object HerringboneGear {
 
@@ -17,22 +18,22 @@ object HerringboneGear {
    * @param backlash add some space (manufacturing tolerance)
    * @param skew generate a gear with an asymmetric profile by skewing the tooths
    */
-  def apply( pitch: Double,
+  def apply( pitch: Length,
              nbrTeeth: Int,
              pressureAngle: Double,
-             addenum: Double,
-             dedenum: Double,
-             height: Double,
-             helixAngle: Double,
-             backlash: Double,
+             addenum: Length,
+             dedenum: Length,
+             height: Length,
+             twist: Twist,
+             backlash: Length,
              skew: Double = 0.0) = {
     val stepped = InvoluteGear.stepped(pitch, nbrTeeth, pressureAngle, addenum, dedenum, height, backlash, skew)
     def turnPoint(p: Point): Point = {
       val z = p.z
-      val a = if (z < height/2) helixAngle * z
-              else helixAngle * (height - z)
-      val x = p.x * cos(a) - p.y * sin(a)
-      val y = p.x * sin(a) + p.y * cos(a)
+      val a = if (z < height/2) twist.angle * (z / twist.increment)
+              else twist.angle * ((height - z) / twist.increment)
+      val x = p.x * a.cos - p.y * a.sin
+      val y = p.x * a.sin + p.y * a.cos
       Point(x, y, z)
     }
     Polyhedron(stepped.faces.map( f => Face(turnPoint(f.p1), turnPoint(f.p2), turnPoint(f.p3)) ))

--- a/src/main/scala/scadla/utils/gear/Involute.scala
+++ b/src/main/scala/scadla/utils/gear/Involute.scala
@@ -2,6 +2,8 @@ package scadla.utils.gear
   
 import scadla._
 import scala.math._
+import squants.space.Length
+import squants.space.Millimeters
 
 object Involute {
   
@@ -13,40 +15,40 @@ object Involute {
   //  ρ = r * sqrt(1 + a^2)
   //  φ = a - arctan(a)
 
-  def x(radius: Double, phase: Double, theta: Double): Double = {
+  def x(radius: Length, phase: Double, theta: Double): Length = {
     radius * (cos(theta) + (theta - phase) * sin(theta))
   }
 
-  def y(radius: Double, phase: Double, theta: Double): Double = {
+  def y(radius: Length, phase: Double, theta: Double): Length = {
     radius * (sin(theta) - (theta - phase) * cos(theta))
   }
   
-  def x(radius: Double, theta: Double): Double = x(radius, 0, theta)
-  def y(radius: Double, theta: Double): Double = x(radius, 0, theta)
+  def x(radius: Length, theta: Double): Length = x(radius, 0, theta)
+  def y(radius: Length, theta: Double): Length = y(radius, 0, theta)
 
-  def x(theta: Double): Double = x(1, theta)
-  def y(theta: Double): Double = x(1, theta)
+  //def x(theta: Double): Double = x(1, theta)
+  //def y(theta: Double): Double = y(1, theta)
 
 
 
-  def apply(radius: Double, phase: Double, start: Double, end: Double, height: Double, stepSize: Double): Polyhedron = {
-    assert(radius > 0)
+  def apply(radius: Length, phase: Double, start: Double, end: Double, height: Length, stepSize: Double): Polyhedron = {
+    assert(radius.value > 0)
     assert(end > start)
-    assert(height > 0)
+    assert(height.value > 0)
     assert(stepSize > 0)
 
     val steps = ceil((end - start) / stepSize).toInt
     val actualStepSize = (end - start) / steps
 
     val points = Array.ofDim[Point](2 * (2 + steps))
-    points(0) = Point(0,0,0)
-    points(1) = Point(0,0,height)
+    points(0) = Point(Millimeters(0),Millimeters(0),Millimeters(0))
+    points(1) = Point(Millimeters(0),Millimeters(0),height)
 
     for (i <- (0 to steps)) {
       val theta = start + i * actualStepSize
       val x1 = x(radius, phase, theta)
       val y1 = y(radius, phase, theta)
-      points(2*(i+1)    ) = Point(x1, y1, 0)
+      points(2*(i+1)    ) = Point(x1, y1, Millimeters(0))
       points(2*(i+1) + 1) = Point(x1, y1, height)
     }
 
@@ -69,7 +71,7 @@ object Involute {
     Polyhedron(faces)
   }
   
-  def apply(radius: Double, start: Double, end: Double, height: Double): Polyhedron = {
+  def apply(radius: Length, start: Double, end: Double, height: Length): Polyhedron = {
     apply(radius, 0, start, end, height, 0.1)
   }
     

--- a/src/main/scala/scadla/utils/gear/Rack.scala
+++ b/src/main/scala/scadla/utils/gear/Rack.scala
@@ -4,23 +4,26 @@ import scadla._
 import scadla.InlineOps._
 import scadla.utils._
 import scala.math._
+import squants.space.Length
+import squants.space.Radians
+import squants.space.Millimeters
 
 object Rack {
 
   //for carving so the backlash makes the tooth larger
-  def tooth( toothWidth: Double,
+  def tooth( toothWidth: Length,
              pressureAngle: Double,
-             addenum: Double,
-             dedenum: Double,
-             height: Double,
-             backlash: Double,
+             addenum: Length,
+             dedenum: Length,
+             height: Length,
+             backlash: Length,
              skew: Double ) = {
     assert(pressureAngle < Pi / 2 && pressureAngle >= 0, "pressureAngle must be between in [0;π/2)")
     val base = toothWidth + 2 * addenum * tan(pressureAngle) + backlash
     val tip  = toothWidth - 2 * dedenum * tan(pressureAngle) + backlash
-    assert(tip > 0, "tip of the profile is negative ("+tip+"), try decreasing the pressureAngle, or addenum/dedenum.")
+    assert(tip.value > 0, "tip of the profile is negative ("+tip+"), try decreasing the pressureAngle, or addenum/dedenum.")
     val tHeight = addenum + dedenum + backlash
-    Trapezoid(tip, base, height, tHeight, skew).rotateX(Pi/2).move(-base/2 + addenum*tan(skew), addenum, 0).rotateZ(-Pi/2)
+    Trapezoid(tip, base, height, tHeight, skew).rotateX(Radians(Pi/2)).move(-base/2 + addenum*tan(skew), addenum, Millimeters(0)).rotateZ(Radians(-Pi/2))
   }
   
   /** Create an involute spur gear.
@@ -33,25 +36,25 @@ object Rack {
    * @param backlash add some space (manufacturing tolerance)
    * @param skew generate a gear with an asymmetric profile by skewing the tooths
    */
-  def apply( toothWidth: Double,
+  def apply( toothWidth: Length,
              nbrTeeth: Int,
              pressureAngle: Double,
-             addenum: Double,
-             dedenum: Double,
-             height: Double,
-             backlash: Double,
+             addenum: Length,
+             dedenum: Length,
+             height: Length,
+             backlash: Length,
              skew: Double = 0.0) = {
 
-    assert(addenum > 0, "addenum must be greater than 0")
-    assert(dedenum > 0, "dedenum must be greater than 0")
+    assert(addenum.value > 0, "addenum must be greater than 0")
+    assert(dedenum.value > 0, "dedenum must be greater than 0")
     assert(nbrTeeth > 0, "number of tooths must be greater than 0")
-    assert(toothWidth > 0, "toothWidth must be greater than 0")
+    assert(toothWidth.value > 0, "toothWidth must be greater than 0")
 
     val rackTooth = tooth(toothWidth, pressureAngle, addenum, dedenum, height, -backlash, skew)
 
     val space = 2*toothWidth
     val teeth = for (i <- 0 until nbrTeeth) yield rackTooth.moveY(i * space)
-    val base = Cube(Gear.baseThickness, nbrTeeth * space, height).move(dedenum, -space/2, 0)
+    val base = Cube(Gear.baseThickness, nbrTeeth * space, height).move(dedenum, -space/2, Millimeters(0))
     base ++ teeth
   }
 

--- a/src/main/scala/scadla/utils/gear/Twist.scala
+++ b/src/main/scala/scadla/utils/gear/Twist.scala
@@ -1,0 +1,22 @@
+package scadla.utils.gear
+
+import squants.space.Angle
+import squants.space.Length
+import squants.space.Degrees
+import squants.space.Radians
+import squants.space.Millimeters
+
+/**
+ * Represents an amount of twist [helix] per certain [increment] along a path.
+ */
+case class Twist(angle: Angle, increment: Length) {
+  def * (d: Double) = Twist(angle * d, increment)
+  def / (d: Double) = Twist(angle / d, increment)
+  def unary_-() = Twist(-angle, increment)
+}
+
+object Twist {
+  def apply(pitch: Length): Twist = Twist(Degrees(360), pitch)
+  
+  def radiansPerMm(value: Double): Twist = Twist(Radians(value), Millimeters(1))
+}

--- a/src/main/scala/scadla/utils/package.scala
+++ b/src/main/scala/scadla/utils/package.scala
@@ -1,6 +1,9 @@
 package scadla
 
 import math._
+import squants.space.Length
+import scala.language.postfixOps
+import scadla.InlineOps._
 
 package object utils {
 
@@ -60,18 +63,19 @@ package object utils {
     case other => f(acc, other)
   }
 
+  private val Zero = 0°
   def simplify(s: Solid): Solid = {
     def rewrite(s: Solid): Solid = s match {
-      case Cube(width, depth, height) if width <= 0.0 || depth <= 0.0 || height <= 0.0 => Empty
-      case Sphere(radius) if radius <= 0.0 => Empty
-      case Cylinder(radiusBot, radiusTop, height) if height <= 0.0 => Empty
+      case Cube(width, depth, height) if width.value <= 0.0 || depth.value <= 0.0 || height.value <= 0.0 => Empty
+      case Sphere(radius) if radius.value <= 0.0 => Empty
+      case Cylinder(radiusBot, radiusTop, height) if height.value <= 0.0 => Empty
       //TODO order the points/faces to get a normal form
       case Polyhedron(triangles) if triangles.isEmpty => Empty
 
       case Translate(x1, y1, z1, Translate(x2, y2, z2, s2)) => Translate(x1+x2, y1+y2, z1+z2, s2)
-      case Rotate(x1, 0, 0, Rotate(x2, 0, 0, s2)) => Rotate(x1+x2, 0, 0, s2)
-      case Rotate(0, y1, 0, Rotate(0, y2, 0, s2)) => Rotate(0, y1+y2, 0, s2)
-      case Rotate(0, 0, z1, Rotate(0, 0, z2, s2)) => Rotate(0, 0, z1+z2, s2)
+      case Rotate(x1, Zero, Zero, Rotate(x2, Zero, Zero, s2)) => Rotate(x1+x2, Zero, Zero, s2)
+      case Rotate(Zero, y1, Zero, Rotate(Zero, y2, Zero, s2)) => Rotate(Zero, y1+y2, Zero, s2)
+      case Rotate(Zero, Zero, z1, Rotate(Zero, Zero, z2, s2)) => Rotate(Zero, Zero, z1+z2, s2)
       case Scale(x1, y1, z1, Scale(x2, y2, z2, s2)) => Scale(x1*x2, y1*y2, z1*z2, s2)
       
       //TODO flatten ops

--- a/src/test/scala/scadla/utils/PackageTest.scala
+++ b/src/test/scala/scadla/utils/PackageTest.scala
@@ -2,6 +2,7 @@ package scadla.utils
 
 import scadla._
 import org.scalatest._
+import scadla.EverythingIsIn.{millimeters, radians}  
 
 class PackageTest extends FunSuite {
 


### PR DESCRIPTION
Currently, lengths, angles and time are all just Doubles, which introduces
a possibility for error. Scala's type system allows for very rich units
which the [squants](https://github.com/typelevel/squants) library leverages.

Although STL, OpenSCAD and others are "unit-less" where it comes to
lengths, they're not unit-less on angles. Plus, it makes sense to be
specific where possible, e.g. when mixing inches and mm in one project.

This commit introduces type-safe units in most places, but leaves the
examples as-is, interpreting everything in millimeter or radians.